### PR TITLE
로그인 페이지 추가, 로그인 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
-.env*.local
+.env*
 
 # vercel
 .vercel

--- a/api/config.ts
+++ b/api/config.ts
@@ -1,0 +1,1 @@
+export const TILOG_API = process.env.TILOG_API;

--- a/api/core.ts
+++ b/api/core.ts
@@ -1,0 +1,7 @@
+import * as TILog from "@til-log.lab/tilog-api";
+import { TILOG_API } from "api/config";
+
+export const config = new TILog.Configuration({
+  basePath: TILOG_API,
+});
+export const tilogApi = new TILog.DefaultApi(config);

--- a/api/getUserInfo.ts
+++ b/api/getUserInfo.ts
@@ -1,0 +1,15 @@
+import { tilogApi } from "api/core";
+export const getUserInfo = () => {
+  return new Promise<string>(async (resolve, reject) => {
+    try {
+      const {
+        data: { accessToken },
+      } = await tilogApi.usersAuthControllerGetAccessTokenUsingRefreshToken(
+        "tilog"
+      );
+      resolve(accessToken);
+    } catch (error) {
+      reject(error.response.data.message[0].message);
+    }
+  });
+};

--- a/api/getUserInfo.ts
+++ b/api/getUserInfo.ts
@@ -1,4 +1,6 @@
+import axios from "axios";
 import { tilogApi } from "api/core";
+import { isExceptionMessageInterface } from "interface/MessageError";
 export const getUserInfo = () => {
   return new Promise<string>(async (resolve, reject) => {
     try {
@@ -9,7 +11,10 @@ export const getUserInfo = () => {
       );
       resolve(accessToken);
     } catch (error) {
-      reject(error.response.data.message[0].message);
+      if (!axios.isAxiosError(error)) return reject("");
+      const errorData = error.response?.data ?? [];
+      if (!isExceptionMessageInterface(errorData)) return reject("");
+      reject(errorData.message[0].message);
     }
   });
 };

--- a/context/Login.tsx
+++ b/context/Login.tsx
@@ -1,0 +1,16 @@
+import { createContext, ReactNode, useState } from "react";
+import OLogin from "src/components/Organisms/Login";
+export const LoginContext = createContext({});
+
+export const LoginModalProvider = ({ children }: { children: ReactNode }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpen = () => {
+    setIsOpen(!isOpen);
+  };
+  return (
+    <LoginContext.Provider value={handleOpen}>
+      {isOpen && <OLogin />}
+      {children}
+    </LoginContext.Provider>
+  );
+};

--- a/interface/MessageError.ts
+++ b/interface/MessageError.ts
@@ -1,0 +1,19 @@
+export const COUNTRY = {
+  ko: "ko",
+  en: "en",
+} as const;
+
+export const isExceptionMessageInterface = (
+  object: any
+): object is ExceptionMessageInterface => {
+  const hadMessage = object ? "message" in object : false;
+  const hadCountryFlag = object?.message[0]?.countryFlag;
+  return !!(hadMessage && hadCountryFlag);
+};
+export interface ExceptionMessageInterface {
+  message: ExceptionMessageItemInterface[];
+}
+export interface ExceptionMessageItemInterface {
+  countryFlag: typeof COUNTRY[keyof typeof COUNTRY];
+  message: string;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-module.exports = nextConfig
+const withTM = require("next-transpile-modules")(["@til-log.lab/tilog-api"]);
+
+module.exports = withTM({
+  nextConfig,
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tiptap/starter-kit": "^2.0.0-beta.183",
     "axios": "^0.26.1",
     "next": "12.1.4",
+    "next-transpile-modules": "^9.0.0",
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-hook-form": "^7.29.0"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@til-log.lab/tilog-api": "^0.0.3",
     "@tiptap/react": "^2.0.0-beta.108",
     "@tiptap/starter-kit": "^2.0.0-beta.183",
+    "axios": "^0.26.1",
     "next": "12.1.4",
     "react": "18.0.0",
     "react-dom": "18.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,22 @@
+import type { AppContext, AppProps } from "next/app";
+import { config } from "api/core";
 import "../styles/globals.css";
-import type { AppProps } from "next/app";
 
-const MyApp = ({ Component, pageProps }: AppProps) => {
+const TILogApp = ({ Component, pageProps }: AppProps) => {
   return <Component {...pageProps} />;
 };
 
-export default MyApp;
+TILogApp.getInitialProps = async (context: AppContext) => {
+  const { ctx, Component } = context;
+  let pageProps = {};
+
+  const headers = ctx.req?.headers;
+  config.baseOptions = { headers: headers };
+  console.log(Component);
+  if (Component.getInitialProps) {
+    pageProps = await Component.getInitialProps(ctx);
+  }
+
+  return { pageProps };
+};
+export default TILogApp;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,3 +1,4 @@
+import { getUserInfo } from "api/getUserInfo";
 import type { NextPage } from "next";
 import OLogin from "src/components/Organisms/Login";
 
@@ -8,5 +9,20 @@ const LoginPage: NextPage = () => {
     </div>
   );
 };
-
+export async function getServerSideProps() {
+  try {
+    await getUserInfo();
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      props: {},
+    };
+  }
+}
 export default LoginPage;

--- a/src/components/Molecules/Button/Login.tsx
+++ b/src/components/Molecules/Button/Login.tsx
@@ -1,10 +1,9 @@
-interface MButtonLoginProps {
-  onClick?: () => void;
-}
-
-const MButtonLogin = ({ onClick }: MButtonLoginProps) => {
+const MButtonLogin = () => {
+  const handleLogin = async () => {
+    window.open("http://localhost/auth/github/login");
+  };
   return (
-    <button onClick={onClick} className={`rounded bg-black w-72 h-12`}>
+    <button onClick={handleLogin} className={`rounded bg-black w-72 h-12`}>
       <p className="text-sm text-white">Login With Github</p>
     </button>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,6 +179,11 @@
     lodash.isplainobject "^4.0.6"
     lodash.merge "^4.6.2"
 
+"@til-log.lab/tilog-api@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@til-log.lab/tilog-api/-/tilog-api-0.0.3.tgz#ef655696874710c892c1ca95270f968e5184eea2"
+  integrity sha512-4wVYijfLiTaC9hgeQvL+PBNkV/F2XfvruDjSnjvbC7C/HVulZh+CbKSCKeeqtNXCFHh0g7GNb8VdHiLPA2fzAQ==
+
 "@tiptap/core@^2.0.0-beta.174":
   version "2.0.0-beta.174"
   resolved "https://registry.yarnpkg.com/@tiptap/core/-/core-2.0.0-beta.174.tgz#cfdf16b7d7401e4b255dc69147d784f5f537b942"
@@ -751,6 +756,13 @@ axe-core@^4.3.5:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
+
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -1449,6 +1461,11 @@ flatted@^3.1.0:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
+
+follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 fraction.js@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,6 +1027,14 @@ emoji-regex@^9.2.2:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
+enhanced-resolve@^5.7.0:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz#44a342c012cbc473254af5cc6ae20ebd0aae5d88"
+  integrity sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -1566,6 +1574,11 @@ globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+graceful-fs@^4.2.4:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
 has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
@@ -1914,6 +1927,14 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+next-transpile-modules@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz#133b1742af082e61cc76b02a0f12ffd40ce2bf90"
+  integrity sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==
+  dependencies:
+    enhanced-resolve "^5.7.0"
+    escalade "^3.1.1"
 
 next@12.1.4:
   version "12.1.4"
@@ -2534,6 +2555,11 @@ tailwindcss@^3.0.23:
     postcss-value-parser "^4.2.0"
     quick-lru "^5.1.1"
     resolve "^1.22.0"
+
+tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
# 구현 개요

## 작업 사항

tilog-open-api, next-transpile-modules 설치

전역 app에 client header를 server에게 전달해주는 로직 작성

로그인 페이지 추가 및 로그인 구현

## 이슈 트래커 번호

resolve #19 
