### PR TITLE
TextInput 재사용성을 생각하여 컴포넌트를 다시 작성하라.

### DIFF
--- a/src/components/atom/input/TextInput.tsx
+++ b/src/components/atom/input/TextInput.tsx
@@ -18,17 +18,14 @@ const TextInput = <TFormValues extends unknown>({
   register,
   inputName,
   rules,
+  className,
   errorMessage,
   ...props
 }: TextInputProps<TFormValues>) => {
   return (
     <>
       <input
-        className={`${
-          !errorMessage
-            ? "dark:focus:border-signature-color focus:border-signature-color"
-            : "focus:border-red-600 dark:focus:border-rose-600"
-        } py-2.5 w-full bg-transparent border-0 border-b-2 border-gray-300 appearance-none dark:border-gray-600 focus:outline-none focus:ring-0`}
+        className={`py-2.5 w-full ${className}`}
         {...register(inputName, rules)}
         {...props}
       />

--- a/src/components/molecules/input/settings/DisplayNameInput.tsx
+++ b/src/components/molecules/input/settings/DisplayNameInput.tsx
@@ -31,6 +31,11 @@ const DisplayNameInput = () => {
         rules={displayNameRules("ko")}
         inputName="DISPLAY_NAME"
         errorMessage={errorMessage}
+        className={`${
+          !errorMessage
+            ? "dark:focus:border-signature-color focus:border-signature-color"
+            : "focus:border-red-600 dark:focus:border-rose-600"
+        } bg-transparent border-0 border-b-2 border-gray-300 appearance-none dark:border-gray-600 focus:outline-none focus:ring-0`}
       />
     </div>
   );

--- a/src/components/molecules/input/settings/EmailInput.tsx
+++ b/src/components/molecules/input/settings/EmailInput.tsx
@@ -31,6 +31,11 @@ const EmailInput = () => {
         rules={emailRules("ko")}
         inputName="EMAIL"
         errorMessage={errorMessage}
+        className={`${
+          !errorMessage
+            ? "dark:focus:border-signature-color focus:border-signature-color"
+            : "focus:border-red-600 dark:focus:border-rose-600"
+        } bg-transparent border-0 border-b-2 border-gray-300 appearance-none dark:border-gray-600 focus:outline-none focus:ring-0`}
       />
     </div>
   );

--- a/src/components/molecules/input/settings/IntroductionInput.tsx
+++ b/src/components/molecules/input/settings/IntroductionInput.tsx
@@ -31,6 +31,11 @@ const IntroductionInput = () => {
         rules={introMsgRules("ko")}
         inputName="INTRO_MSG"
         errorMessage={errorMessage}
+        className={`${
+          !errorMessage
+            ? "dark:focus:border-signature-color focus:border-signature-color"
+            : "focus:border-red-600 dark:focus:border-rose-600"
+        } bg-transparent border-0 border-b-2 border-gray-300 appearance-none dark:border-gray-600 focus:outline-none focus:ring-0`}
       />
     </div>
   );

--- a/src/components/molecules/input/settings/PositionInput.tsx
+++ b/src/components/molecules/input/settings/PositionInput.tsx
@@ -31,6 +31,11 @@ const PositionInput = () => {
         rules={positionRules("ko")}
         inputName="POSITION"
         errorMessage={errorMessage}
+        className={`${
+          !errorMessage
+            ? "dark:focus:border-signature-color focus:border-signature-color"
+            : "focus:border-red-600 dark:focus:border-rose-600"
+        } bg-transparent border-0 border-b-2 border-gray-300 appearance-none dark:border-gray-600 focus:outline-none focus:ring-0`}
       />
     </div>
   );


### PR DESCRIPTION
<!-- PR 제목 양식
   PR 제목이 깃 히스토리에 기록됨으로 반드시 어떤 요소를 개발 했는지 명시해 주세요
 -->

# 구현 개요
TextInput 재사용성 높히기
<!-- 어떤 기능을 개발했나요? -->

## 작업 사항
TextInput의 재사용성을 위해 수정
Settings 컴포넌트에만 집중되어있는 스타일을 외부에서 스타일을 주입받 을 수 있도록 수정하였습니다.

atom-TextInput): 수정 반영
TextInput 수정에 대한 반영 및 Setting만의 스타일을 부모 컴포넌트에서 하위 컴포넌트로 내려주도록 작성하였습니다.
<!-- 어떤 작업을 하셨나요? -->

## 이슈 트래커 번호

resolve #193  