### PR TITLE
자식 컴포넌트 key 에러 해결

### DIFF
--- a/src/components/common/molecules/card/post/MostPopularPostCard.tsx
+++ b/src/components/common/molecules/card/post/MostPopularPostCard.tsx
@@ -14,10 +14,7 @@ const MostPopularPostCard = ({ index, post }: MostPopularPostCardProps) => {
   return (
     <div className="flex justify-center">
       <h6 className="w-4 mr-2">{index}.</h6>
-      <div
-        key={post.id}
-        className="w-full md:w-[350px] bg-neutral-100 dark:bg-neutral-800"
-      >
+      <div className="w-full md:w-[350px] bg-neutral-100 dark:bg-neutral-800">
         <div className="p-4">
           <PostUserProfile
             viewCount={post.view}

--- a/src/components/common/molecules/card/post/PostCard.tsx
+++ b/src/components/common/molecules/card/post/PostCard.tsx
@@ -8,10 +8,7 @@ import { GetPostsItem } from "@til-log.lab/tilog-api";
 
 const PostCard = ({ post }: { post: GetPostsItem }) => {
   return (
-    <div
-      key={post.id}
-      className="flex flex-col lg:flex-row bg-neutral-100 dark:bg-neutral-800 lg:max-w-[600px] w-full"
-    >
+    <div className="flex flex-col lg:flex-row bg-neutral-100 dark:bg-neutral-800 lg:max-w-[600px] w-full">
       <div className="w-full p-4 md:py-4 md:pl-4">
         <PostUserProfile
           viewCount={post.view}

--- a/src/components/common/organisms/list/CategorySortButtonList.tsx
+++ b/src/components/common/organisms/list/CategorySortButtonList.tsx
@@ -22,7 +22,10 @@ const CategorySortButtonList = ({
       <div className="m-auto max-w-[1280px] items-center px-5">
         <div className="py-3 overflow-y-auto scrollbar-hide">
           {categoryList.data.data.list.map((category) => (
-            <CategorySortButton categoryName={category.categoryName} />
+            <CategorySortButton
+              key={category.id}
+              categoryName={category.categoryName}
+            />
           ))}
         </div>
       </div>

--- a/src/components/common/organisms/list/MostPopularPostCardList.tsx
+++ b/src/components/common/organisms/list/MostPopularPostCardList.tsx
@@ -43,7 +43,7 @@ const MostPopularPostCardList = ({
     <div>
       <div className="grid grid-row md:grid-cols-2 xl:grid-cols-3 gap-y-3">
         {postList.data.data.list.map((post, idx) => (
-          <MostPopularPostCard index={idx + 1} post={post} />
+          <MostPopularPostCard key={post.id} index={idx + 1} post={post} />
         ))}
       </div>
     </div>

--- a/src/components/common/organisms/list/PostCardList.tsx
+++ b/src/components/common/organisms/list/PostCardList.tsx
@@ -49,7 +49,9 @@ const PostCardList = ({
           postList.data.pages.map((postPage) => {
             if (isArrayEmpty(postPage.data.list))
               return <h3>인기 게시글이 없습니다.</h3>;
-            return postPage.data.list.map((post) => <PostCard post={post} />);
+            return postPage.data.list.map((post) => (
+              <PostCard key={post.id} post={post} />
+            ));
           })}
       </div>
       <CardLoading

--- a/src/components/modules/comment/index.tsx
+++ b/src/components/modules/comment/index.tsx
@@ -19,7 +19,7 @@ const Comment = ({ postId }: CommentProps) => {
     <div>
       <hr />
       {commentList.data.data.list.map((comment) => (
-        <RootComment comment={comment} />
+        <RootComment key={comment.id} comment={comment} />
       ))}
       <CommentInput
         postId={postId}

--- a/src/components/modules/comment/render/RootComment.tsx
+++ b/src/components/modules/comment/render/RootComment.tsx
@@ -47,7 +47,7 @@ const RootComment = ({ comment }: RootCommentProps) => {
           {isOpen &&
             childCommentList.isSuccess &&
             childCommentList.data.data.list.map((childComment) => (
-              <CommentRender comment={childComment} />
+              <CommentRender key={childComment.id} comment={childComment} />
             ))}
           {isOpen && (
             <CommentInput


### PR DESCRIPTION
<!-- PR 제목 양식
   PR 제목이 깃 히스토리에 기록됨으로 반드시 어떤 요소를 개발 했는지 명시해 주세요
 -->

# 구현 개요
자식 컴포넌트 key 에러 해결
<!-- 어떤 기능을 개발했나요? -->

## 작업 사항
React Key를 자식컴포넌트에 다는 것이 아닌 부모 컴포넌트에 달아줘야 합니다.
Virtual Dom의 동작 과정중 재조합에 의해 성능 저하가 발생하므로 Key를 부모에게 설정해줘야합니다.
<!-- 어떤 작업을 하셨나요? -->

## 이슈 트래커 번호

 resolve #349 
